### PR TITLE
add default to Monitor.waitForAbort for timeout

### DIFF
--- a/xbmc.py
+++ b/xbmc.py
@@ -780,7 +780,7 @@ class Monitor(object):
         """
         pass
 
-    def waitForAbort(self, timeout):
+    def waitForAbort(self, timeout=0):
         """
         Block until abort is requested, or until timeout occurs.
 


### PR DESCRIPTION
timeout is optional so set a default value to prevent syntax error highlighting
